### PR TITLE
Add elemental weakness and range defence types

### DIFF
--- a/builders/monsters/build_monster.py
+++ b/builders/monsters/build_monster.py
@@ -265,23 +265,27 @@ class BuildMonster:
         # Initialize a dictionary that maps database_name -> property_name
         # The database_name is used in this project
         # The property_name is used by the OSRS Wiki
-        combat_bonuses = {"attack_level": "att",
-                          "strength_level": "str",
-                          "defence_level": "def",
-                          "magic_level": "mage",
-                          "ranged_level": "range",
-                          "attack_bonus": "attbns",
-                          "strength_bonus": "strbns",
-                          "attack_magic": "amagic",
-                          "magic_bonus": "mbns",
-                          "attack_ranged": "arange",
-                          "ranged_bonus": "rngbns",
-                          "defence_stab": "dstab",
-                          "defence_slash": "dslash",
-                          "defence_crush": "dcrush",
-                          "defence_magic": "dmagic",
-                          "defence_ranged": "drange",
-                          }
+        combat_bonuses = {
+            "attack_level": "att",
+            "strength_level": "str",
+            "defence_level": "def",
+            "magic_level": "mage",
+            "ranged_level": "range",
+            "attack_bonus": "attbns",
+            "strength_bonus": "strbns",
+            "attack_magic": "amagic",
+            "magic_bonus": "mbns",
+            "attack_ranged": "arange",
+            "ranged_bonus": "rngbns",
+            "defence_stab": "dstab",
+            "defence_slash": "dslash",
+            "defence_crush": "dcrush",
+            "defence_magic": "dmagic",
+            "defence_ranged": "drange",
+            "elemental_weakness_type": "elementalweaknesstype",
+            "elemental_weakness_percent": "elementalweaknesspercent"
+        }
+
 
         # Loop each of the combat bonuses and populate
         for database_name, property_name in combat_bonuses.items():

--- a/builders/monsters/build_monster.py
+++ b/builders/monsters/build_monster.py
@@ -281,7 +281,9 @@ class BuildMonster:
             "defence_slash": "dslash",
             "defence_crush": "dcrush",
             "defence_magic": "dmagic",
-            "defence_ranged": "drange",
+            "defence_ranged_light": "dlight",
+            "defence_ranged_standard": "dstandard",
+            "defence_ranged_heavy": "dheavy",
             "elemental_weakness_type": "elementalweaknesstype",
             "elemental_weakness_percent": "elementalweaknesspercent"
         }
@@ -321,6 +323,15 @@ class BuildMonster:
             value = value.strip()
             return value
         except ValueError:
+            # If dlight, dstandard, dheavy do not exist, chances are all are the same and given by drange
+            for prefix in ("light", "standard", "heavy"):
+                if f'd{prefix}' in key:
+                    alt_key = key.replace(f'd{prefix}', 'drange')
+                    try:
+                        value = template.get(alt_key).value.strip()
+                        return value
+                    except ValueError:
+                        return value
             return value
 
     def check_duplicate_monster(self) -> MonsterProperties:

--- a/builders/monsters/infobox_cleaner.py
+++ b/builders/monsters/infobox_cleaner.py
@@ -424,12 +424,24 @@ def examine(value: str) -> bool:
 
 
 def stats(value: str) -> int:
-    """Convert a monster stat value to an integer.
+    """Convert a monster stat or elemental value to an integer.
 
     :param value: Template value extracted from raw wikitext.
-    :return value: A cleaned stat value as an int.
+    :return: A cleaned stat value as an int, or mapped elemental value.
     """
+    elemental_map = {
+        "Air": 1,
+        "Water": 2,
+        "Earth": 3,
+        "Fire": 4
+    }
+
+    value = value.strip().capitalize()
+    if value in elemental_map:
+        return elemental_map[value]
+
     try:
         return int(value)
     except ValueError:
         return 0
+

--- a/data/schemas/schema-monsters.json
+++ b/data/schemas/schema-monsters.json
@@ -414,8 +414,20 @@
     "required": false,
     "nullable": true
   },
-  "defence_ranged": {
-    "description": "The defence ranged bonus of the monster.",
+  "defence_ranged_light": {
+    "description": "The defence ranged bonus of the monster against light ammo.",
+    "type": "integer",
+    "required": true,
+    "nullable": false
+  },
+  "defence_ranged_standard": {
+    "description": "The defence ranged bonus of the monster against medium ammo.",
+    "type": "integer",
+    "required": true,
+    "nullable": false
+  },
+  "defence_ranged_heavy": {
+    "description": "The defence ranged bonus of the monster against heavy ammo.",
     "type": "integer",
     "required": true,
     "nullable": false

--- a/data/schemas/schema-monsters.json
+++ b/data/schemas/schema-monsters.json
@@ -402,6 +402,18 @@
     "required": true,
     "nullable": false
   },
+  "elemental_weakness_type": {
+    "description": "Elemental weakness type of the monster (mapped to int).",
+    "type": "integer",
+    "required": false,
+    "nullable": true
+  },
+  "elemental_weakness_percent": {
+    "description": "Elemental weakness percent of the monster.",
+    "type": "integer",
+    "required": false,
+    "nullable": true
+  },
   "defence_ranged": {
     "description": "The defence ranged bonus of the monster.",
     "type": "integer",

--- a/osrsreboxed/monsters_api/monster_properties.py
+++ b/osrsreboxed/monsters_api/monster_properties.py
@@ -81,7 +81,9 @@ class MonsterProperties:
     defence_magic: int = None
     elemental_weakness_type: int = None
     elemental_weakness_percent: int = None
-    defence_ranged: int = None
+    defence_ranged_light: int = None
+    defence_ranged_standard: int = None
+    defence_ranged_heavy: int = None
     drops: List = None
 
     @classmethod

--- a/osrsreboxed/monsters_api/monster_properties.py
+++ b/osrsreboxed/monsters_api/monster_properties.py
@@ -79,6 +79,8 @@ class MonsterProperties:
     defence_slash: int = None
     defence_crush: int = None
     defence_magic: int = None
+    elemental_weakness_type: int = None
+    elemental_weakness_percent: int = None
     defence_ranged: int = None
     drops: List = None
 


### PR DESCRIPTION
- Adds elemental weaknesses to monsters. To minimise changes, I kept structure of monster stats being all ints, and encoded weakness type to none = 0, air = 1, water = 2, earth = 3, fire = 4, which is quite standard. 

- Adds range defence for light, standard and heavy ammo. These three replace `defence_range` completely, unlike in the API where `drange` is still used if they are al the same. However, i think this is better for users who expect the same info as in the infobox. 

Closes #10 